### PR TITLE
LH-74887: Merge the cdFMC OpenAPI docs with the public API YAML

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -186,15 +186,28 @@ cli_download_command() {
   # src/download_command.sh
   root_dir=$(dirname $(dirname $(readlink -f "$0")))
   filename=openapi.yaml
-  declare -A urls=( ["public-api"]="https://edge.staging.cdo.cisco.com/api/platform/public-api/v3/api-docs.yaml" ["object-service"]="https://edge.staging.cdo.cisco.com/api/platform/object-service/v3/api-docs.yaml" )
+  declare -A urls=(
+    ["public-api"]="https://edge.staging.cdo.cisco.com/api/platform/public-api/v3/api-docs.yaml"
+    ["object-service"]="https://edge.staging.cdo.cisco.com/api/platform/object-service/v3/api-docs.yaml"
+    # Currently dependent on the acme tenant cdFMC - need to update
+    ["cdFmc-service"]="https://cdo-acme.app.staging.cdo.cisco.com/api/api-explorer/fmc_oas3.json"
+  )
 
   filenames=()
   for service in "${!urls[@]}"; do
-      filename="${service}-openapi.yaml"
-      filenames+=("${root_dir}/${filename}")
       url=${urls[${service}]}
-      echo -n "$(yellow Downloading file from) $(yellow_underlined ${url}) to $(blue_bold ${root_dir}/${filename})... "
-      curl -X GET --silent --url  "${url}" -o $root_dir/$filename
+      filename="${service}-openapi.yaml"
+      if [[ "$service" == "cdFmc-service" ]]; then
+        echo -n "Downloading and converting cdFmc-service JSON to YAML... "
+        curl -s "$url" | \
+        # Replace cdFMC URLs with the new Public API proxy URL
+        jq '.paths |= with_entries(.key |= gsub("api/fmc_platform/"; "v1/cdfmc/api/fmc_platform/"))' | \
+        yq e -P - > "${root_dir}/${filename}"
+      else
+        echo -n "$(yellow Downloading file from) $(yellow_underlined ${url}) to $(blue_bold ${root_dir}/${filename})... "
+        curl -X GET --silent --url  "${url}" -o $root_dir/$filename
+      fi
+      filenames+=("${root_dir}/${filename}")
       echo "✅︎"
   done
 

--- a/scripts/src/download_command.sh
+++ b/scripts/src/download_command.sh
@@ -1,14 +1,27 @@
 root_dir=$(dirname $(dirname $(readlink -f "$0")))
 filename=openapi.yaml
-declare -A urls=( ["public-api"]="https://edge.staging.cdo.cisco.com/api/platform/public-api/v3/api-docs.yaml" ["object-service"]="https://edge.staging.cdo.cisco.com/api/platform/object-service/v3/api-docs.yaml" )
+declare -A urls=(
+    ["public-api"]="https://edge.staging.cdo.cisco.com/api/platform/public-api/v3/api-docs.yaml"
+    ["object-service"]="https://edge.staging.cdo.cisco.com/api/platform/object-service/v3/api-docs.yaml"
+    # Currently dependent on the acme tenant cdFMC - need to update
+    ["cdFmc-service"]="https://cdo-acme.app.staging.cdo.cisco.com/api/api-explorer/fmc_oas3.json"
+)
 
 filenames=()
 for service in "${!urls[@]}"; do
-    filename="${service}-openapi.yaml"
-    filenames+=("${root_dir}/${filename}")
     url=${urls[${service}]}
-    echo -n "$(yellow Downloading file from) $(yellow_underlined ${url}) to $(blue_bold ${root_dir}/${filename})... "
-    curl -X GET --silent --url  "${url}" -o $root_dir/$filename
+    filename="${service}-openapi.yaml"
+    if [[ "$service" == "cdFmc-service" ]]; then
+        echo -n "Downloading and converting cdFmc-service JSON to YAML... "
+        curl -s "$url" | \
+        # Replace cdFMC URLs with the new Public API proxy URL
+        jq '.paths |= with_entries(.key |= gsub("api/fmc_platform/"; "v1/cdfmc/api/fmc_platform/"))' | \
+        yq e -P - > "${root_dir}/${filename}"
+    else
+        echo -n "$(yellow Downloading file from) $(yellow_underlined ${url}) to $(blue_bold ${root_dir}/${filename})... "
+        curl -X GET --silent --url  "${url}" -o $root_dir/$filename
+    fi
+    filenames+=("${root_dir}/${filename}")
     echo "✅︎"
 done
 


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-74887

This one adds the `fmc_oas3.json` to the public API, it converts the file into yaml file and replaces cdFMC URLs with the new Public API proxy URL.
Currently dependent on acme tenant cdFMC, will be updated after investigating with @Kunal Goswami.