### PR TITLE
LH-79100: Clear previous build artifacts before creating the SDK pkg

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -397,6 +397,7 @@ cli_publish_python_sdk_command() {
   pip3 install wheel twine
 
   echo -n "$(yellow Creating the Wheel and Source)... "
+  rm -rf dist/ build/ *.egg-info
   python3 setup.py sdist bdist_wheel
 
   echo -n "$(yellow Publishing to PyPI)... "

--- a/scripts/src/publish_python_sdk_command.sh
+++ b/scripts/src/publish_python_sdk_command.sh
@@ -12,6 +12,7 @@ cd cdo-sdk/python
 pip3 install wheel twine
 
 echo -n "$(yellow Creating the Wheel and Source)... "
+rm -rf dist/ build/ *.egg-info
 python3 setup.py sdist bdist_wheel
 
 echo -n "$(yellow Publishing to PyPI)... "


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-79100

 an attempt to fix the missing module's error from the latest SDK version

