### PR TITLE
docs(lh-83794): add changelog information for v1.3.0 of the API

### DIFF
--- a/api-changelog.md
+++ b/api-changelog.md
@@ -1,3 +1,12 @@
+# Version 1.2.0 (2024-xx-xx) 
+>**Note**:
+This changelog is a work in progress. Update the date and ensure it has all the necessary information before sending a publication request to Devnet.
+
+- cdFMC health monitoring: API endpoint to monitor the health of a cloud-delivered FMC (cdFMC).
+- Provisioning: Provision a cdFMC and enable Multicloud Defense on a CDO tenant.
+- MSSP Tenant management: Endpoints to add user groups, provision a cdFMC, and enable Multicloud Defense on a CDO tenant that is associated with a CDO MSSP Portal.
+- Improvements to the devices endpoint: The **Get Devices** endpoint now provides information on the redundancy mode of a firewall, and provides additional High Availability (HA) and clustering information for FTD HA Pairs and clusters.
+
 # Version 1.2.0 (2024-07-19)
 
 ## Added


### PR DESCRIPTION
This changelog info should be updated whenever we add a big tranche of additional endpoints so we do
not have to remember to update it.
