### PR TITLE
Fix SDK name for PEP 625 compliance

### DIFF
--- a/cdo-sdk/python/setup.py
+++ b/cdo-sdk/python/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages  # noqa: H301
 #
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
-NAME = "cdo-sdk-python"
+NAME = "cdo_sdk_python"
 VERSION = "1.2.413"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [


### PR DESCRIPTION
Updated SDK name to cdo_sdk_python to resolve PyPI deprecation warnings.