### PR TITLE
feat(lh-89724): allow appending custom prefixes to microservice APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Go to [https://devnetapps.cisco.com/docs/cisco-defense-orchestrator/].
 ```yaml
   - name: "my-new-service"
     url: "https://staging.manage.security.cisco.com/api/platform/my-new-service/v3/api-docs.yaml"
+    # Optional: if your endpoints are accessible on /api/platform/myapp/foos, but the public-api-gateway makes them available on /api/rest/v1/bars/foos, you should specify /v1/bars as the prefix. Start with a /, and no trailing slashes.
+    prefixToAdd: "/v1/bars"
 ```
 - Edit `api-changelog.md` to add a short description of what APIs your new microservice provides.
 - Submit a PR (please see commit message guidelines).

--- a/cloud-fw-mgr-api-docs.config.yaml
+++ b/cloud-fw-mgr-api-docs.config.yaml
@@ -11,6 +11,7 @@ services:
     url: "https://staging.manage.security.cisco.com/api/platform/transaction-service/v3/api-docs.yaml"
   - name: "device-gateway-service"
     url: "https://edge.staging.cdo.cisco.com/api/platform/device-gateway/v3/api-docs.yaml"
+    prefixToAdd: "/v1/onpremfmc/gateway"
 info:
   title: "Cisco Security Cloud Control API"
   version: "1.5.0"

--- a/scripts/golang/models/config.go
+++ b/scripts/golang/models/config.go
@@ -1,8 +1,9 @@
 package models
 
 type Service struct {
-	Name string `yaml:"name"`
-	URL  string `yaml:"url"`
+	Name        string  `yaml:"name"`
+	URL         string  `yaml:"url"`
+	PrefixToAdd *string `yaml:"prefixToAdd"`
 }
 type Info struct {
 	Title       string  `yaml:"title"`

--- a/scripts/golang/services/openapi_merger_service.go
+++ b/scripts/golang/services/openapi_merger_service.go
@@ -22,7 +22,7 @@ func MergeOpenApiSpecs(serviceSpecs map[string]*models.OpenAPI, config *models.C
 	for serviceName, spec := range serviceSpecs {
 		var prefixToAdd *string
 		for _, service := range config.Services {
-			if service.Name == serviceName {
+			if service.Name == serviceName && service.PrefixToAdd != nil {
 				trimmedPrefix := strings.TrimSuffix(*service.PrefixToAdd, "/")
 				if !strings.HasPrefix(trimmedPrefix, "/") {
 					trimmedPrefix = "/" + trimmedPrefix

--- a/scripts/golang/services/openapi_merger_service_test.go
+++ b/scripts/golang/services/openapi_merger_service_test.go
@@ -9,6 +9,8 @@ import (
 
 var _ = Describe("MergeOpenApiSpecs", func() {
 	It("should merge multiple OpenAPI specs", func() {
+		prefixToAddForService1 := "v1/another-custom-prefix/"
+		prefixToAddForService2 := "/custom-prefix"
 		config := models.Config{
 			Info: models.Info{
 				Title:       "API Docs",
@@ -23,6 +25,16 @@ var _ = Describe("MergeOpenApiSpecs", func() {
 				URL:         "https://edge.us.cdo.cisco.com",
 				Description: "US",
 			}},
+			Services: []models.Service{
+				{
+					Name:        "service1",
+					URL:         "https://service1.us.cdo.cisco.com",
+					PrefixToAdd: &prefixToAddForService1,
+				}, {
+					Name:        "service2",
+					URL:         "https://service2.us.cdo.cisco.com",
+					PrefixToAdd: &prefixToAddForService2,
+				}},
 		}
 
 		service1Paths := map[string]interface{}{
@@ -77,6 +89,11 @@ var _ = Describe("MergeOpenApiSpecs", func() {
 		Expect(mergedSpec.Paths).To(HaveLen(4))
 		Expect(mergedSpec.Components.Schemas).To(HaveLen(3))
 		Expect(mergedSpec.Components.Responses).To(HaveLen(3))
+		// Verify that /path3 and /path4 are labeled /custom-prefix/path3 and /custom-prefix/path4
+		Expect(mergedSpec.Paths).To(HaveKey("/v1/another-custom-prefix/path1"))
+		Expect(mergedSpec.Paths).To(HaveKey("/v1/another-custom-prefix/path2"))
+		Expect(mergedSpec.Paths).To(HaveKey("/custom-prefix/path3"))
+		Expect(mergedSpec.Paths).To(HaveKey("/custom-prefix/path4"))
 	})
 
 	It("Should fail on conflicting paths", func() {


### PR DESCRIPTION
Add a new optional field to services defined in `cloud-fw-mgr-api-docs.config.yml` called
`prefixToAdd`, which specifies a prefix to add to each of the paths in that application. For
example, if your endpoints are accessible on /api/platform/myapp/foos, but the public-api-gateway
makes them available on /api/rest/v1/bars/foos, you should specify /v1/bars as the prefix.
