### PR TITLE
fix(lh-89658): fix minor bug in Python SDK generation

### DIFF
--- a/scripts/golang/services/sdks_service.go
+++ b/scripts/golang/services/sdks_service.go
@@ -29,7 +29,7 @@ func GeneratePythonSdk(openapiFile string, version string, useLocalInstallation 
 		"-i", openapiFile,
 		"-g", "python",
 		"-o", "sdks/python",
-		"--additional-properties=packageName=cdo-sdk-python,packageVersion="+version).Output()
+		"--additional-properties=packageName=cdo_sdk_python,packageVersion="+version).Output()
 	return err
 }
 

--- a/scripts/golang/services/sdks_service_test.go
+++ b/scripts/golang/services/sdks_service_test.go
@@ -45,7 +45,7 @@ var _ = Describe("SdksService", func() {
 					// validate args
 					Expect(name).To(Equal("npx"))
 					Expect(args).To(HaveLen(9))
-					Expect(args).To(Equal([]string{"./node_modules/@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo-sdk-python,packageVersion=" + version}))
+					Expect(args).To(Equal([]string{"./node_modules/@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo_sdk_python,packageVersion=" + version}))
 
 					output := "test output"
 					return &MockCommandExecutor{output: &output}
@@ -64,7 +64,7 @@ var _ = Describe("SdksService", func() {
 				// validate args
 				Expect(name).To(Equal("npx"))
 				Expect(args).To(HaveLen(9))
-				Expect(args).To(Equal([]string{"@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo-sdk-python,packageVersion=" + version}))
+				Expect(args).To(Equal([]string{"@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo_sdk_python,packageVersion=" + version}))
 
 				output := "test output"
 				return &MockCommandExecutor{output: &output}
@@ -82,7 +82,7 @@ var _ = Describe("SdksService", func() {
 				// validate args
 				Expect(name).To(Equal("npx"))
 				Expect(args).To(HaveLen(9))
-				Expect(args).To(Equal([]string{"@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo-sdk-python,packageVersion=" + version}))
+				Expect(args).To(Equal([]string{"@openapitools/openapi-generator-cli", "generate", "-i", openapiFile, "-g", "python", "-o", "sdks/python", "--additional-properties=packageName=cdo_sdk_python,packageVersion=" + version}))
 
 				return &MockCommandExecutor{err: errors.New(expectedErrMsg)}
 			}


### PR DESCRIPTION
We were generating Python SDKs with `-` rather than `_` in the name. That was breaking everything.
Fix it.
