### PR TITLE
fix: bump openapi-generator to 7.14.0 for OpenAPI 3.1 support

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.4.0"
+    "version": "7.14.0"
   }
 }


### PR DESCRIPTION
The Spring Boot 4 migration (LH-107134) switched springdoc to emit OpenAPI 3.1 specs. openapi-generator 7.4.0 bundles swagger-parser 2.1.18, whose 3.1 validation incorrectly rejects `default` on object and array schemas, failing SDK generation with 312 "default is not of type" errors across every service spec.

Bump the generator engine to 7.14.0 (swagger-parser 2.1.28), which handles OpenAPI 3.1 correctly.